### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "aaemnnosttv/wp-cli-login-command",
     "description": "Login to WordPress with secure passwordless magic links.",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/aaemnnosttv/wp-cli-login-command",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567