### PR TITLE
Added possibility to change the link timeout duration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Create a magic sign-in link for the given user.  Outputs the created URL with so
 
 > `<user>` can be passed as an User ID, username/login or email address. This is the same for all `login` commands which accept this as a parameter.
 
+### `Magic link timeout`
+
+By default the expiration timeout for the link is set to *15 minutes*, but that can be overriden by setting the `WP_CLI_LOGIN_TIMEOUT_DURATION` environment variable (`~/.bashrc`, `~/.zshrc`, `~/.profile`) in ***minutes***.
+
 #### `--url-only`
 
 Outputs the created sign-in URL only. Great for scripting, piping to your clipboard, or anything else you can think of.

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -65,7 +65,7 @@ class LoginCommand
         WP_CLI::line(str_repeat('-', strlen($magic_url)));
         WP_CLI::line($magic_url);
         WP_CLI::line(str_repeat('-', strlen($magic_url)));
-        WP_CLI::line('This link will self-destruct in 15 minutes, or as soon as it is used; whichever comes first.');
+        WP_CLI::line('This link will self-destruct in '. $this->get_env_timeout() .' minutes, or as soon as it is used; whichever comes first.');
 
         if (WP_CLI\Utils\get_flag_value($assoc, 'launch')) {
             $this->launch($magic_url);
@@ -124,8 +124,9 @@ class LoginCommand
 
         $magic_url = $this->makeMagicUrl($user);
         $domain  = $this->domain();
+        $link_timeout = $this->get_env_timeout();
 
-        return \WP_CLI\Utils\mustache_render($template_file, compact('magic_url','domain'));
+        return \WP_CLI\Utils\mustache_render($template_file, compact('magic_url','domain','link_timeout'));
     }
 
     /**

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -339,6 +339,25 @@ class LoginCommand
     }
 
     /**
+     * Magic link timeout
+     *
+     * @param  WP_User $user User to create login URL for
+     *
+     * @return string  URL
+     */
+    private function get_env_timeout()
+    {
+        /**
+         * Link timeout default variable
+         */
+        $link_timeout_duration = getenv('WP_CLI_LOGIN_TIMEOUT_DURATION') ? getenv('WP_CLI_LOGIN_TIMEOUT_DURATION') : '15';
+        if (is_numeric($link_timeout_duration))
+            return $link_timeout_duration;
+        else
+            return $link_timeout_duration;
+    }
+
+    /**
      * Create a magic login URL
      *
      * @param  WP_User $user User to create login URL for
@@ -359,7 +378,7 @@ class LoginCommand
             'time'    => time(),
         ];
 
-        set_transient(self::OPTION . '/' . $public, json_encode($magic), MINUTE_IN_SECONDS * 15);
+        set_transient(self::OPTION . '/' . $public, json_encode($magic), MINUTE_IN_SECONDS * $this->get_env_timeout());
 
         return home_url("$endpoint/$public");
     }

--- a/template/email-default.mustache
+++ b/template/email-default.mustache
@@ -24,7 +24,7 @@
         {{ magic_url }}
     </p>
 
-    <p style="color: #444444;"><strong>This login link, whether or not you choose to accept it, will self-destruct in 15 minutes.</strong></p>
+    <p style="color: #444444;"><strong>This login link, whether or not you choose to accept it, will self-destruct in {{ link_timeout }} minutes.</strong></p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Added possibility to change the link timeout duration using environment variable. Defaults to 15 minutes as initially intended.

Setting the WP_CLI_LOGIN_TIMEOUT_DURATION as an environment variable will change the duration of the link to that specified duration. Fallbacks to the initial 15 minutes for the timeout.