### PR TITLE
Add support for WP-CLI's global URL flag

### DIFF
--- a/plugin/wp-cli-login-server.php
+++ b/plugin/wp-cli-login-server.php
@@ -6,7 +6,7 @@
  * Author URI: https://aaemnnost.tv
  * Plugin URI: https://aaemnnost.tv/wp-cli-commands/login/
  *
- * Version: 1.1
+ * Version: 1.2
  */
 
 namespace WP_CLI_Login;

--- a/plugin/wp-cli-login-server.php
+++ b/plugin/wp-cli-login-server.php
@@ -227,6 +227,19 @@ class WP_CLI_Login_Server
 
         return "$this->publicKey|$this->endpoint|$domain|$user->ID";
     }
+
+    /**
+     * Get the home URL.
+     *
+     * @return string
+     */
+    private function homeUrl()
+    {
+        /* wp-cli server-command filters home & siteurl to work and saves the original in a global. */
+        return isset($GLOBALS['_wp_cli_original_url'])
+            ? $GLOBALS['_wp_cli_original_url']
+            : home_url();
+    }
 }
 
 class BadMagic extends Exception

--- a/plugin/wp-cli-login-server.php
+++ b/plugin/wp-cli-login-server.php
@@ -223,9 +223,12 @@ class WP_CLI_Login_Server
      */
     private function signature(WP_User $user)
     {
-        $domain = parse_url(home_url(), PHP_URL_HOST);
-
-        return "$this->publicKey|$this->endpoint|$domain|$user->ID";
+        return join('|', [
+            $this->publicKey,
+            $this->endpoint,
+            parse_url($this->homeUrl(), PHP_URL_HOST),
+            $user->ID,
+        ]);
     }
 
     /**

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -21,7 +21,7 @@ class LoginCommand
     /**
      * Required version constraint of the wp-cli-login-server companion plugin.
      */
-    const REQUIRED_PLUGIN_VERSION = '^1.1';
+    const REQUIRED_PLUGIN_VERSION = '^1.2';
 
     /**
      * Package instance

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -372,7 +372,7 @@ class LoginCommand
 
         $this->persistMagicUrl($magic, $endpoint, $expires);
 
-        return home_url($endpoint . '/' . $magic->getKey());
+        return $this->homeUrl($endpoint . '/' . $magic->getKey());
     }
 
     /**
@@ -475,6 +475,29 @@ class LoginCommand
     private function domain()
     {
         return parse_url(home_url(), PHP_URL_HOST);
+    }
+
+    /**
+     * Get the home URL.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function homeUrl($path = '')
+    {
+        $url = home_url($path);
+
+        /**
+         * If the global --url is passed it will set the HTTP_HOST
+         */
+        if (! empty($_SERVER['HTTP_HOST'])) {
+            $url = preg_replace('#//[^/]+#', '//'. $_SERVER['HTTP_HOST'], $url, 1);
+
+            return set_url_scheme($url);
+        }
+
+        return $url;
     }
 
     /**

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -489,12 +489,12 @@ class LoginCommand
         $url = home_url($path);
 
         /**
-         * If the global --url is passed it will set the HTTP_HOST
+         * If the global --url is passed it will set the HTTP_HOST.
+         * Here we replace the hostname in the default home URL with the one set by the command.
+         * This preserves compatibility with sites installed as a subdirectory.
          */
         if (! empty($_SERVER['HTTP_HOST'])) {
-            $url = preg_replace('#//[^/]+#', '//'. $_SERVER['HTTP_HOST'], $url, 1);
-
-            return set_url_scheme($url);
+            return preg_replace('#//[^/]+#', '//'. $_SERVER['HTTP_HOST'], $url, 1);
         }
 
         return $url;


### PR DESCRIPTION
Currently using the global `--url=asdf.xyz` WP-CLI flag does not alter the behavior of the generated magic link as expected.  This causes problems when attempting to use it to login to a sub-site on a multisite install or when using `wp server` to serve through localhost or another domain.

Resolves #6 