### PR TITLE
Use WP_CLI::runcommand in stead of WP_CLI::run_command

### DIFF
--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -350,8 +350,11 @@ class LoginCommand
         self::debug("Toggling companion plugin: $setState");
 
         $command = $setState == 'on' ? 'activate' : 'deactivate';
+        $options = array(
+            'return' => true,
+        );
 
-        WP_CLI::run_command(['plugin', $command, 'wp-cli-login-server']);
+        WP_CLI::runcommand('plugin '.$command.' wp-cli-login-server', $options);
     }
 
     /**

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -350,11 +350,8 @@ class LoginCommand
         self::debug("Toggling companion plugin: $setState");
 
         $command = $setState == 'on' ? 'activate' : 'deactivate';
-        $options = array(
-            'return' => true,
-        );
 
-        WP_CLI::runcommand('plugin '.$command.' wp-cli-login-server', $options);
+        WP_CLI::runcommand("plugin $command wp-cli-login-server");
     }
 
     /**


### PR DESCRIPTION
Using WP_CLI::runcommand is recomended: https://make.wordpress.org/cli/handbook/internal-api/wp-cli-run-command/

I use fabric (http://www.fabfile.org/) to interact with WP sites. When I ran 'wp login install --activate' I got a failed result with message: 'Success: Companion plugin installed.'. The success message was from installing the plugin, but the error code 1 came from activating the plugin. After making this change installing and activating goes smooth.
