### PR TITLE
Add support for login hooks

### DIFF
--- a/plugin/wp-cli-login-server.php
+++ b/plugin/wp-cli-login-server.php
@@ -184,7 +184,25 @@ class WP_CLI_Login_Server
     private function loginUser(WP_User $user)
     {
         delete_transient($this->magicKey());
+
         wp_set_auth_cookie($user->ID);
+
+        /**
+         * Fires after the user has successfully logged in via the WP-CLI Login Server.
+         *
+         * @param string  $user_login Username.
+         * @param WP_User $user       WP_User object of the logged-in user.
+         */
+        do_action('wp_cli_login/login', $user->user_login, $user);
+
+        /**
+         * Fires after the user has successfully logged in.
+         *
+         * @param string  $user_login Username.
+         * @param WP_User $user       WP_User object of the logged-in user.
+         */
+        do_action('wp_login', $user->user_login, $user);
+
         wp_redirect(admin_url());
         exit;
     }

--- a/plugin/wp-cli-login-server.php
+++ b/plugin/wp-cli-login-server.php
@@ -228,9 +228,10 @@ class WP_CLI_Login_Server
          * Filters the login redirect URL for WP-CLI Login Server requests.
          *
          * @param string           $redirect_to           The redirect destination URL.
+         * @param string           $requested_redirect_to The requested redirect destination URL passed as a parameter.
          * @param WP_User          $user                  WP_User object.
          */
-        $redirect_to = apply_filters('wp_cli_login/login_redirect', $redirect_to, $user);
+        $redirect_to = apply_filters('wp_cli_login/login_redirect', $redirect_to, '', $user);
 
         /**
          * Figure out where to redirect the user for the default wp-admin URL based on the user's capabilities.


### PR DESCRIPTION
This PR adds support for hooks login fired during a normal login request.

This includes the `wp_login` action and the `login_redirect` filter.

It also includes login command-specific hooks for those who wish to target cli logins specifically using the `wp_cli_login/login` action and the `wp_cli_login/login_redirect` filter.

These hooks may be used to integrate with existing monitoring/audit plugins or for additional custom functionality.

Resolves #13 
