### PR TITLE
Allow server/companion plugin to be installed as an mu-plugin

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -333,8 +333,12 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
     }
 
     public function install_login_server_plugin($activate) {
-	    $activate = $activate ? '--activate' : '';
-        $this->proc("wp login install --yes $activate", ['path' => $this->variables['WP_DIR']])->run_check();
+	    if ('mu' === $activate) {
+            $this->proc("wp login install --mu", ['path' => $this->variables['WP_DIR']])->run_check();
+        } else {
+            $activate = $activate ? '--activate' : '';
+            $this->proc("wp login install --yes $activate", ['path' => $this->variables['WP_DIR']])->run_check();
+        }
     }
 }
 

--- a/features/login-create.feature
+++ b/features/login-create.feature
@@ -14,6 +14,16 @@ Feature: Users can generate single-use magic links that will log them in automat
       Success: Magic login link created!
       """
 
+  @install:mu @issue:14
+  Scenario: It works without activation when installed as an mu plugin.
+    Given a WP install
+    And the login plugin is installed as an mu plugin
+    When I try `wp login create admin`
+    Then STDOUT should contain:
+      """
+      Success: Magic login link created!
+      """
+
   Scenario: It can generate magic login URLs using a user ID, login, or email address.
     Given a WP install
     And the login plugin is installed and active
@@ -105,7 +115,7 @@ Feature: Users can generate single-use magic links that will log them in automat
       410 Gone
       """
 
-  @issue-7
+  @issue:7
   Scenario: It works for subdirectory installs too.
     Given a WP install in 'subdir'
     And a running web server

--- a/features/login-install.feature
+++ b/features/login-install.feature
@@ -4,3 +4,10 @@ Feature: It can install its companion plugin.
     Given a WP install
     When I run `wp login install`
     Then the wp-content/plugins/wp-cli-login-server/wp-cli-login-server.php file should exist
+
+  @flag:mu
+  Scenario: The command can be installed as an Must Use plugin.
+    Given a WP install
+    When I run `wp login install --mu`
+    Then the wp-content/mu-plugins/wp-cli-login-server.php file should exist
+    And the wp-content/plugins/wp-cli-login-server/wp-cli-login-server.php file should not exist

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -174,3 +174,6 @@ $steps->Given('/^the login plugin is installed( and active)?$/', function($world
     $world->install_login_server_plugin($active);
 });
 
+$steps->Given('/^the login plugin is installed as an mu plugin$/', function($world) {
+    $world->install_login_server_plugin('mu');
+});

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -442,13 +442,7 @@ class LoginCommand
      */
     private function installedPlugin()
     {
-        static $plugin;
-
-        if (! $plugin) {
-            $plugin = ServerPlugin::installed();
-        }
-
-        return $plugin;
+        return ServerPlugin::installed();
     }
 
     /**
@@ -458,13 +452,7 @@ class LoginCommand
      */
     private function bundledPlugin()
     {
-        static $plugin;
-
-        if (! $plugin) {
-            $plugin = new ServerPlugin($this->packagePath('plugin/wp-cli-login-server.php'));
-        }
-
-        return $plugin;
+        return new ServerPlugin($this->packagePath('plugin/wp-cli-login-server.php'));
     }
 
     /**

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -420,7 +420,7 @@ class LoginCommand
     {
         $plugin = $this->installedPlugin();
 
-        if (! ServerPlugin::isActive() || ! $plugin->exists()) {
+        if (! ServerPlugin::isActive()) {
             WP_CLI::error('This command requires the companion plugin to be installed and active. Run `wp login install --activate` and try again.');
         }
 

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -272,6 +272,9 @@ class LoginCommand
      * [--activate]
      * : Activate the plugin after installing.
      *
+     * [--mu]
+     * : Install as a Must Use plugin.
+     *
      * [--yes]
      * : Suppress confirmation to overwrite the installed plugin if it exists.
      *
@@ -282,7 +285,12 @@ class LoginCommand
     {
         static::debug('Installing plugin.');
 
-        $installed = $this->installedPlugin();
+        if (\WP_CLI\Utils\get_flag_value($assoc, 'mu')) {
+            $installed = ServerPlugin::mustUse();
+        } else {
+            $installed = $this->installedPlugin();
+        }
+
         $suppress_prompt = \WP_CLI\Utils\get_flag_value($assoc, 'yes');
 
         if ($installed->exists() && ! $suppress_prompt && ! $this->confirmOverwrite($installed)) {

--- a/src/MustUseServerPlugin.php
+++ b/src/MustUseServerPlugin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace WP_CLI_Login;
+
+class MustUseServerPlugin extends ServerPlugin
+{
+    const PLUGIN_FILE = 'wp-cli-login-server.php';
+
+    public static function isActive()
+    {
+        return true;
+    }
+}

--- a/src/ServerPlugin.php
+++ b/src/ServerPlugin.php
@@ -35,7 +35,7 @@ class ServerPlugin
      */
     public static function isActive()
     {
-        return is_plugin_active(self::PLUGIN_FILE);
+        return class_exists(WP_CLI_Login_Server::class, false);
     }
 
     /**

--- a/src/ServerPlugin.php
+++ b/src/ServerPlugin.php
@@ -3,6 +3,7 @@
 namespace WP_CLI_Login;
 
 use Composer\Semver\Semver;
+use WP_CLI_Login\WP_CLI_Login_Server;
 
 class ServerPlugin
 {
@@ -44,7 +45,21 @@ class ServerPlugin
      */
     public static function installed()
     {
+        $must_use = static::mustUse();
+
+        if ($must_use->exists()) {
+            return $must_use;
+        }
+
         return new static(WP_PLUGIN_DIR . '/' . static::PLUGIN_FILE);
+    }
+
+    /**
+     * @return MustUseServerPlugin
+     */
+    public static function mustUse()
+    {
+        return new MustUseServerPlugin(WPMU_PLUGIN_DIR . '/' . basename(static::PLUGIN_FILE));
     }
 
     /**


### PR DESCRIPTION
This PR adds support for the login server plugin to be installed as a Must Use plugin on the site.

Previously, this would cause commands to fail as if the plugin was not installed.

To install the companion plugin as an mu-plugin via the cli, simply pass the `--mu` flag to `login install` 😎 

Resolves #14 