### PR TITLE
Fix build and update tested versions of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ services:
   - mysql
 
 php:
-  - 5.5
   - 5.6
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 install: composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+services:
+  - mysql
+
 php:
   - 5.5
   - 5.6


### PR DESCRIPTION
Newer distributions of Travis don't start the mysql service for more performant test runs and require that it be declared to be started automatically.

https://docs.travis-ci.com/user/reference/xenial#services-disabled-by-default

Also updates the build matrix to test newer versions of PHP.