### PR TITLE
Custom email subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Email a magic sign-in link to the given user.  Sends a nice HTML email to the us
 
 [See above.](#--expiresseconds)
 
+#### `--subject=<email-subject>`
+
+Optionally override the default email subject with your own custom string. You may use the `{{ domain }}` placeholder.
+
+Default: Magic log-in link for {{domain}}
+
 #### `--template=<path-to-custom-template>`
 
 Optionally override the default email template with your own by providing the path to a different template file to use.

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -149,9 +149,10 @@ class LoginCommand
     private function renderEmailSubject($template_data, $subject)
     {
         $m = new \Mustache_Engine(
-        array(
-            'escape' => function ( $val ) {
-                return $val; },
+            array(
+                'escape' => function ($val) {
+                    return $val;
+                },
             )
         );
         return $m->render($subject, $template_data);

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -96,6 +96,12 @@ class LoginCommand
      * default: 900
      * ---
      *
+     * [--subject=<email-subject>]
+     * : The email subject field.
+     * ---
+     * default: Magic log-in link for {{domain}}
+     * ---
+     *
      * [--template=<path-to-template-file>]
      * : The path to a file to use for a custom email template.
      * Uses Mustache templating for dynamic html.
@@ -116,16 +122,39 @@ class LoginCommand
         $expires       = human_time_diff(time(), time() + absint($assoc['expires']));
         $magic_url     = $this->makeMagicUrl($user, $assoc['expires']);
         $domain        = $this->domain();
+        $subject       = $this->renderEmailSubject(
+            compact('domain'),
+            $assoc['subject']
+        );
         $html_rendered = $this->renderEmailTemplate(
             compact('magic_url','domain','expires'),
             $assoc['template']
         );
 
-        if (! $this->sendEmail($user, $domain, $html_rendered)) {
+        if (! $this->sendEmail($user, $domain, $subject, $html_rendered)) {
             WP_CLI::error('Email failed to send.');
         }
 
         WP_CLI::success('Email sent.');
+    }
+
+    /**
+     * Render the given email subject, for the given user.
+     *
+     * @param $template_data
+     * @param $subject
+     *
+     * @return string
+     */
+    private function renderEmailSubject($template_data, $subject)
+    {
+        $m = new \Mustache_Engine(
+        array(
+            'escape' => function ( $val ) {
+                return $val; },
+            )
+        );
+        return $m->render($subject, $template_data);
     }
 
     /**
@@ -533,16 +562,17 @@ class LoginCommand
      *
      * @param $user
      * @param $domain
+     * @param $subject
      * @param $html_rendered
      *
      * @return bool|void
      */
-    private function sendEmail($user, $domain, $html_rendered)
+    private function sendEmail($user, $domain, $subject, $html_rendered)
     {
         static::debug("Sending email to $user->user_email");
 
         return wp_mail($user->user_email,
-            "Magic log-in link for $domain",
+            $subject,
             $html_rendered,
             [
                 'Content-Type: text/html',

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -122,9 +122,9 @@ class LoginCommand
         $expires       = human_time_diff(time(), time() + absint($assoc['expires']));
         $magic_url     = $this->makeMagicUrl($user, $assoc['expires']);
         $domain        = $this->domain();
-        $subject       = $this->renderEmailSubject(
-            compact('domain'),
-            $assoc['subject']
+        $subject       = $this->mustacheRender(
+            $assoc['subject'],
+            compact('domain')
         );
         $html_rendered = $this->renderEmailTemplate(
             compact('magic_url','domain','expires'),
@@ -139,14 +139,14 @@ class LoginCommand
     }
 
     /**
-     * Render the given email subject, for the given user.
+     * Render the given mustache template string.
      *
-     * @param $template_data
-     * @param $subject
+     * @param $template
+     * @param $data
      *
      * @return string
      */
-    private function renderEmailSubject($template_data, $subject)
+    private function mustacheRender($template, $data = [])
     {
         $m = new \Mustache_Engine(
             array(
@@ -155,7 +155,7 @@ class LoginCommand
                 },
             )
         );
-        return $m->render($subject, $template_data);
+        return $m->render($template, $data);
     }
 
     /**

--- a/src/LoginCommand.php
+++ b/src/LoginCommand.php
@@ -149,11 +149,11 @@ class LoginCommand
     private function mustacheRender($template, $data = [])
     {
         $m = new \Mustache_Engine(
-            array(
+            [
                 'escape' => function ($val) {
                     return $val;
                 },
-            )
+            ]
         );
         return $m->render($template, $data);
     }


### PR DESCRIPTION
Adds ability to override default subject in email command. See also #31.

```
wp login email <user> --subject='Custom email subject for login to {{domain}}'
```