### PR TITLE
Build/core updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 
 cache:
   directories:
-    - vendor
+    - $HOME/.cache/composer
 
 before_deploy:
   - openssl aes-256-cbc -K $encrypted_70f7c684b483_key -iv $encrypted_70f7c684b483_iv -in deploy/key.enc -out deploy/key -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ services:
 
 php:
   - 5.6
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 install: composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ deploy:
   on:
     condition: [[ $TRAVIS_TAG == server-* ]]
     tags: true
-    php: 7.0
+    php: 7.4

--- a/command.php
+++ b/command.php
@@ -6,6 +6,10 @@ if (! class_exists('WP_CLI')) {
     return;
 }
 
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
 LoginCommand::setPackage(new Package(__DIR__));
 
 \WP_CLI::add_command('login', LoginCommand::class);

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,11 @@
         "composer/semver": "^1.0"
     },
     "require-dev": {
-        "wp-cli/wp-cli": "^1.0",
+        "wp-cli/wp-cli": "^2",
+        "wp-cli/config-command": "^2",
+        "wp-cli/core-command": "^2",
+        "wp-cli/entity-command": "^2",
+        "wp-cli/extension-command": "^2",
         "behat/behat": "~2.5",
         "phpunit/phpunit": "^5 || ^6 || ^7"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "paragonie/random_compat": "^2.0",
         "composer/semver": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "classmap": [ "plugin" ]
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "paragonie/random_compat": "^2.0",
         "composer/semver": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "wp-cli/wp-cli": "^1.0",
         "behat/behat": "~2.5",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^5 || ^6 || ^7"
     },
     "scripts": {
         "test": "phpunit",

--- a/deploy/deploy-plugin.sh
+++ b/deploy/deploy-plugin.sh
@@ -7,7 +7,7 @@ ssh-add deploy/key
 PLUGIN_REPO=git@github.com:aaemnnosttv/wp-cli-login-server.git
 
 # Download git-subsplit
-wget https://cdn.rawgit.com/dflydev/git-subsplit/d77ec9d3e1addd97dca1464eabf95c525f591490/git-subsplit.sh
+wget https://raw.githubusercontent.com/dflydev/git-subsplit/d77ec9d3e1addd97dca1464eabf95c525f591490/git-subsplit.sh
 # Prepare for doing the subsplits
 bash git-subsplit.sh init git@github.com:aaemnnosttv/wp-cli-login-command.git
 # synchronize the plugin directory with its respective repository for the current branch

--- a/tests/unit/WP_CLI_Login_ServerTest.php
+++ b/tests/unit/WP_CLI_Login_ServerTest.php
@@ -2,6 +2,10 @@
 
 use WP_CLI_Login\WP_CLI_Login_Server;
 
+if (! class_exists('PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+}
+
 class WP_CLI_Login_ServerTest extends PHPUnit_Framework_TestCase
 {
     /** @test */


### PR DESCRIPTION
* Updates Travis PHP version matrix to include latest stable (7.4) drop 5.5
* Update job used for plugin deploy
* Use wider version constraint for PHPUnit and update test for compatibility
* Update required version of WP-CLI for tests to use v2
* Replace deprecated rawgit cdn URL with GitHub URL