### PR TITLE
SSO Failing if URL has Trailing Slash

### DIFF
--- a/plugin/wp-cli-login-server.php
+++ b/plugin/wp-cli-login-server.php
@@ -83,10 +83,21 @@ class WP_CLI_Login_Server
      */
     public static function parseUri($uri)
     {
-        return array_slice(
-            array_merge(['',''], explode('/', $uri)),
-            -2
-        );
+        $posturl = $uri[-1];
+        if ( strcmp($posturl, "/") === 0 ) {
+  
+          return array_filter(array_slice(
+                  array_merge(['',''], explode('/', $uri)),
+                  -3
+              ));
+          
+        } else {
+  
+              return array_slice(
+                  array_merge(['',''], explode('/', $uri)),
+                  -2
+              );
+        }
     }
 
     /**


### PR DESCRIPTION
Check for trailing slash first, if exists, set array slice index to -3, if not leave it at -2. This way both endpoint and key exist in both cases.