### PR TITLE
Add support for magic URLs with trailing slashes

### DIFF
--- a/plugin/wp-cli-login-server.php
+++ b/plugin/wp-cli-login-server.php
@@ -6,7 +6,7 @@
  * Author URI: https://aaemnnost.tv
  * Plugin URI: https://aaemnnost.tv/wp-cli-commands/login/
  *
- * Version: 1.3
+ * Version: 1.4
  */
 
 namespace WP_CLI_Login;

--- a/plugin/wp-cli-login-server.php
+++ b/plugin/wp-cli-login-server.php
@@ -83,10 +83,16 @@ class WP_CLI_Login_Server
      */
     public static function parseUri($uri)
     {
-        return array_slice(
-            array_merge(['',''], explode('/', $uri)),
-            -2
-        );
+        $uri = trim($uri, '/');
+        $segments = explode('/', $uri);
+
+        // If there aren't at least 2 segments,
+        // return empty values to always return an array with the same length.
+        if (count($segments) < 2) {
+            return ['', ''];
+        }
+
+        return array_slice($segments, -2);
     }
 
     /**

--- a/tests/unit/WP_CLI_Login_ServerTest.php
+++ b/tests/unit/WP_CLI_Login_ServerTest.php
@@ -15,6 +15,15 @@ class WP_CLI_Login_ServerTest extends TestCase
     }
 
     /** @test */
+    function parses_endpoint_and_key_from_uri_with_trailing_slash()
+    {
+        list($endpoint, $public) = WP_CLI_Login_Server::parseUri('/end/key/');
+
+        $this->assertSame('end', $endpoint);
+        $this->assertSame('key', $public);
+    }
+
+    /** @test */
     function parses_endpoint_and_key_from_uri_for_subdirectory_site()
     {
         list($endpoint, $public) = WP_CLI_Login_Server::parseUri('/abc/end/key');
@@ -23,4 +32,28 @@ class WP_CLI_Login_ServerTest extends TestCase
         $this->assertSame('key', $public);
     }
 
+    /** @test */
+    function parses_endpoint_and_key_from_uri_with_trailing_slash_for_subdirectory_site()
+    {
+        list($endpoint, $public) = WP_CLI_Login_Server::parseUri('/abc/end/key/');
+
+        $this->assertSame('end', $endpoint);
+        $this->assertSame('key', $public);
+    }
+
+    /** @test */
+    function parses_an_endpoint_with_a_single_segment() {
+        list($endpoint, $public) = WP_CLI_Login_Server::parseUri('/abc');
+
+        $this->assertSame('', $endpoint);
+        $this->assertSame('', $public);
+    }
+
+    /** @test */
+    function parses_an_endpoint_with_no_segment() {
+        list($endpoint, $public) = WP_CLI_Login_Server::parseUri('/');
+
+        $this->assertSame('', $endpoint);
+        $this->assertSame('', $public);
+    }
 }


### PR DESCRIPTION
Currently the command always creates URLs without a trailing slash, however there can be cases where a trailing slash is added at the web server level. This PR allows Magic URLs to work the same with or without a trailing slash.

This is a change at the server plugin level so existing installs seeking to benefit from this enhancement would need to re-install the server plugin (`wp login install --yes`) but it isn't a requirement of the command that would require all installs to update.

Resolves #40 